### PR TITLE
Add option to select buckets on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Flags:
                           Address on which to expose metrics and web interface.
       --web.telemetry-path="/metrics"  
                           Path under which to expose metrics.
+      --buckets=BUCKETS   A comma delimited list of buckets to use
   -i, --ping.interval=1s  Ping interval duration
       --privileged        Run in privileged ICMP mode
       --log.level="info"  Only log messages with the given severity or above. Valid levels: [debug, info, warn,

--- a/collector.go
+++ b/collector.go
@@ -28,19 +28,33 @@ const (
 var (
 	labelNames = []string{"ip", "host"}
 
+	pingResponseSeconds *prometheus.HistogramVec
+
+	hasRegistered bool
+)
+
+func init() {
+	hasRegistered = false
+}
+
+func setHistogramOptions(buckets []float64) {
 	pingResponseSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "response_duration_seconds",
 			Help:      "A histogram of latencies for ping responses.",
-			Buckets:   prometheus.ExponentialBuckets(0.00005, 2, 20),
+			Buckets:   buckets,
 		},
 		labelNames,
 	)
-)
+}
 
-func init() {
+func registerMetrics() {
+	if hasRegistered {
+		panic("ERROR: called registerMetrics() twice\n")
+	}
 	prometheus.MustRegister(pingResponseSeconds)
+	hasRegistered = true
 }
 
 // SmokepingCollector collects metrics from the pinger.

--- a/collector.go
+++ b/collector.go
@@ -29,11 +29,8 @@ var (
 	labelNames = []string{"ip", "host"}
 )
 
-func init() {
-}
-
-func newPingResponseHistogram(buckets []float64) **prometheus.HistogramVec {
-	pingResponseSeconds := prometheus.NewHistogramVec(
+func newPingResponseHistogram(buckets []float64) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Name:      "response_duration_seconds",
@@ -42,7 +39,6 @@ func newPingResponseHistogram(buckets []float64) **prometheus.HistogramVec {
 		},
 		labelNames,
 	)
-	return &pingResponseSeconds
 }
 
 // SmokepingCollector collects metrics from the pinger.


### PR DESCRIPTION
This diff adds an option to select buckets on command line instead of using the default ones. 

This is my first attempt at any golang code, so I expect you to be brutal ;)

I tried to use kingpin directly, but as far as I can see, I cannot use its powers to magically get a slice of floats instead of parsing it manually.

Closes: #16 