### PR TITLE
Remove dead code 'type pingerList []ping.Pinger'

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,8 +62,6 @@ func HostList(s kingpin.Settings) (target *[]string) {
 	return
 }
 
-type pingerList []ping.Pinger
-
 func init() {
 	prometheus.MustRegister(version.NewCollector("smokeping_prober"))
 }


### PR DESCRIPTION
Linter was complaining about this when I tried to run `make`