### PR TITLE
add self-contained container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
+FROM golang as builder
+
+WORKDIR /go/src/github.com/superq/smokeping_prober
+COPY . .
+RUN make build
+
 FROM quay.io/prometheus/busybox:glibc
 LABEL maintainer="Ben Kochie <superq@gmail.com>"
 
-COPY smokeping_prober /bin/smokeping_prober
+COPY --from=builder /go/src/github.com/superq/smokeping_prober/smokeping_prober /bin/smokeping_prober
 
 EXPOSE 9374
 ENTRYPOINT  [ "/bin/smokeping_prober" ]


### PR DESCRIPTION
Convert Dockerfile to include the build stage. This way it is possible to attach quay/docker hub automated builds for the container image.

Tested on https://quay.io/repository/paulfantom/smokeping_prober