### PR TITLE
Smooth out pings over the interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [ENHANCEMENT] Smooth out pingers over the interval
+
 ## 0.4.0 / 2021-01-31
 
 * [FEATURE] Add support for duplicate packet detection

--- a/main.go
+++ b/main.go
@@ -121,10 +121,15 @@ func main() {
 		pinger.Timeout = time.Duration(math.MaxInt64)
 		pinger.SetPrivileged(*privileged)
 
-		log.Infof("Starting prober for %s", host)
-		go pinger.Run()
-
 		pingers[i] = pinger
+	}
+
+	splay := time.Duration(interval.Nanoseconds() / int64(len(pingers)))
+	log.Infof("Waiting %s between starting pingers", splay)
+	for _, pinger := range pingers {
+		log.Infof("Starting prober for %s", pinger.Addr())
+		go pinger.Run()
+		time.Sleep(splay)
 	}
 
 	prometheus.MustRegister(NewSmokepingCollector(&pingers, *pingResponseSeconds))


### PR DESCRIPTION
Add a splay factor in startup of the pingers to avoid bursty traffic for
a large number pingers.

Signed-off-by: Ben Kochie <superq@gmail.com>