### PR TITLE
Fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
-* [ENHANCEMENT] Smooth out pingers over the interval
+* [ENHANCEMENT] Smooth out pingers over the interval #48
+* [BUGFIX] Fix memory leak #49
 
 ## 0.4.0 / 2021-01-31
 
-* [FEATURE] Add support for duplicate packet detection
+* [FEATURE] Add support for duplicate packet detection #47
 
 ## 0.3.1 / 2020-06-04
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/superq/smokeping_prober
 
 require (
-	github.com/go-ping/ping v0.0.0-20210131131527-30a8f08ad2a9
+	github.com/go-ping/ping v0.0.0-20210201192233-b6486c6f1f2d
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/common v0.15.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-ping/ping v0.0.0-20210131131527-30a8f08ad2a9 h1:wwvZnWxGndQ69htA6zs9hI3fhsn+1KsFuOm5+e0aEHw=
-github.com/go-ping/ping v0.0.0-20210131131527-30a8f08ad2a9/go.mod h1:35JbSyV/BYqHwwRA6Zr1uVDm1637YlNOU61wI797NPI=
+github.com/go-ping/ping v0.0.0-20210201192233-b6486c6f1f2d h1:FKFb1WUcDITAXa5bq97UETgMf0DHeNlPzuTZ6uozlMw=
+github.com/go-ping/ping v0.0.0-20210201192233-b6486c6f1f2d/go.mod h1:35JbSyV/BYqHwwRA6Zr1uVDm1637YlNOU61wI797NPI=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func main() {
 
 		pinger.Interval = *interval
 		pinger.Timeout = time.Duration(math.MaxInt64)
+		pinger.RecordRtts = false
 		pinger.SetPrivileged(*privileged)
 
 		pingers[i] = pinger


### PR DESCRIPTION
Turn off the RTT recorder to avoid leaking memory.

Fixes: https://github.com/SuperQ/smokeping_prober/issues/42

Signed-off-by: Ben Kochie <superq@gmail.com>