### PR TITLE
Add Dynamic host config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/common v0.15.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.3.0
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jakubjastrabik/smokeping_prober v0.4.1 h1:fVhZ67Su6QddM+Om/cntBbLoFKNrmA6to/irms0/N20=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -1,0 +1,16 @@
+targets:
+  - host:
+      ip:
+        - google.sk
+      network: ip4
+      protocol: icmp
+      labels:
+        name: google
+  - host:
+      ip:
+        - fb.com
+        - youtube.com
+      network: ip4
+      protocol: icmp
+      labels:
+        name: fb tr ff


### PR DESCRIPTION
Hi,
I add some example for issue # 37, I chose @SuperQ last ideas with multiple host (FQDN or IP), however I can't know how will be possible make something like blackbox exporter with host definition, because blackbox exp run icmp ping ( probe) after http request (metric scrap) with specific hostname, this exp, run ICMP ping with different timing, so if imagine the probe will be start after http request, we must have same database, or RAM buffer and check if host exist in buffer for pinging does not depend on http request (scrap metric by prometheus)