### PR TITLE
Add option to adjust packet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,21 @@ This prober sends a series of ICMP (or UDP) pings to a target and records the re
 usage: smokeping_prober [<flags>] [<hosts>...]
 
 Flags:
-  -h, --help              Show context-sensitive help (also try --help-long and --help-man).
-      --config.file="smokeping_prober.yml"
-                          Optional smokeping_prober configuration file.
+  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+      --config.file=CONFIG.FILE  Optional smokeping_prober configuration yaml file.
       --web.listen-address=":9374"
-                          Address on which to expose metrics and web interface.
+                                 Address on which to expose metrics and web interface.
       --web.telemetry-path="/metrics"
-                          Path under which to expose metrics.
+                                 Path under which to expose metrics.
       --buckets="5e-05,0.0001,0.0002,0.0004,0.0008,0.0016,0.0032,0.0064,0.0128,0.0256,0.0512,0.1024,0.2048,0.4096,0.8192,1.6384,3.2768,6.5536,13.1072,26.2144"
-                          A comma delimited list of buckets to use
-  -i, --ping.interval=1s  Ping interval duration
-      --privileged        Run in privileged ICMP mode
-      --log.level="info"  Only log messages with the given severity or above. Valid levels: [debug, info, warn,
-                          error, fatal]
-      --log.format="logger:stderr"  
-                          Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or
-                          "logger:stdout?json=true"
-      --version           Show application version.
+                                 A comma delimited list of buckets to use
+  -i, --ping.interval=1s         Ping interval duration
+      --privileged               Run in privileged ICMP mode
+  -s, --ping.size=56             Ping packet size in bytes
+      --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn,
+                                 error]
+      --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
+      --version                  Show application version.
 
 Args:
   [<hosts>]  List of hosts to ping
@@ -52,6 +50,7 @@ targets:
   interval: 1s # Duration, Default 1s.
   network: ip # One of ip, ip4, ip6. Default: ip (automatic IPv4/IPv6)
   protocol: icmp # One of icmp, udp. Default: icmp (Requires privileged operation)
+  size: 56 # Packet data size in bytes. Default 56 (Range: 24 - 65535)
 ```
 
 In each host group the `interval`, `network`, and `protocol` are optional.

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ var (
 		Interval: time.Second,
 		Network:  "ip",
 		Protocol: "icmp",
+		Size:     56,
 	}
 )
 
@@ -92,6 +93,7 @@ type TargetGroup struct {
 	Interval time.Duration `yaml:"interval,omitempty"`
 	Network  string        `yaml:"network,omitempty"`
 	Protocol string        `yaml:"protocol,omitempty"`
+	Size     int           `yaml:"size,omitempty"`
 	// TODO: Needs work to fix MetricFamily consistency.
 	// Labels   map[string]string `yaml:"labels,omitempty"`
 }

--- a/smokeping_prober.yml
+++ b/smokeping_prober.yml
@@ -3,3 +3,4 @@ targets:
 - hosts:
   - localhost
   interval: '0.5s'
+  size: 56


### PR DESCRIPTION
* Add flag to allow packet data size.
* Add config option for size per group.
* Default to 56 bytes (64 byte packet).
* Update docs.

Fixes: https://github.com/SuperQ/smokeping_prober/issues/2

Signed-off-by: SuperQ <superq@gmail.com>