### PR TITLE
Enable native histograms

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -47,13 +47,14 @@ var (
 	)
 )
 
-func newPingResponseHistogram(buckets []float64) *prometheus.HistogramVec {
+func newPingResponseHistogram(buckets []float64, factor float64) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Name:      "response_duration_seconds",
-			Help:      "A histogram of latencies for ping responses.",
-			Buckets:   buckets,
+			Namespace:                   namespace,
+			Name:                        "response_duration_seconds",
+			Help:                        "A histogram of latencies for ping responses.",
+			Buckets:                     buckets,
+			NativeHistogramBucketFactor: factor,
 		},
 		labelNames,
 	)

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ func main() {
 		webConfig   = kingpinflag.AddFlags(kingpin.CommandLine, ":9374")
 
 		buckets    = kingpin.Flag("buckets", "A comma delimited list of buckets to use").Default(defaultBuckets).String()
+		factor     = kingpin.Flag("native-histogram-factor", "The scaling factor for native histogram buckets").Hidden().Default("1.05").Float()
 		interval   = kingpin.Flag("ping.interval", "Ping interval duration").Short('i').Default("1s").Duration()
 		privileged = kingpin.Flag("privileged", "Run in privileged ICMP mode").Default("true").Bool()
 		sizeBytes  = kingpin.Flag("ping.size", "Ping packet size in bytes").Short('s').Default("56").Int()
@@ -135,7 +136,7 @@ func main() {
 		level.Error(logger).Log("msg", "Failed to parse buckets", "err", err)
 		os.Exit(1)
 	}
-	pingResponseSeconds := newPingResponseHistogram(bucketlist)
+	pingResponseSeconds := newPingResponseHistogram(bucketlist, *factor)
 	prometheus.MustRegister(pingResponseSeconds)
 
 	pingers := make([]*probing.Pinger, len(*hosts))


### PR DESCRIPTION
Enable a 1.05 bucket foactor for native histograms. Keep the flag hidden for now until more testing is completed.