### PR TITLE
Replace source with source_address as "source" is a keyword in slog

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func (s *smokePingers) start() {
 	s.started = s.prepared
 	splay := time.Duration(s.maxInterval.Nanoseconds() / int64(len(s.started)))
 	for _, pinger := range s.started {
-		logger.Info("Starting prober", "address", pinger.Addr(), "interval", pinger.Interval, "size_bytes", pinger.Size, "source", pinger.Source)
+		logger.Info("Starting prober", "address", pinger.Addr(), "interval", pinger.Interval, "size_bytes", pinger.Size, "source_address", pinger.Source)
 		s.g.Go(pinger.Run)
 		time.Sleep(splay)
 	}


### PR DESCRIPTION
Replace source with source_address as "source" is a keyword in slog which assumes address of the line in the code, from where invocation happened

Fixes a bug when this segmentation fault occures: 

```
time=2025-01-17T17:42:35.714Z level=INFO source=main.go:227 msg="Starting smokeping_prober" version="(version=0.8.1, branch=master, revision=06d4a90ebc93ca50c0329604c0245a66f4b2de36)"
time=2025-01-17T17:42:35.714Z level=INFO source=main.go:228 msg="Build context" build_context="(go=go1.23.4, platform=linux/arm, user=maskimko@miura, date=20250117-17:31:17, tags=unknown)"
time=2025-01-17T17:42:35.715Z level=INFO source=main.go:237 msg="ignoring missing config file" filename=""
time=2025-01-17T17:42:35.718Z level=INFO source=main.go:143 msg="Pinger resolved" host=miura ip_addr=192.168.1.17
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x595fc8]

goroutine 1 [running]:
github.com/prometheus/common/promslog.init.func2({0xcd2190, 0x0, 0xa}, {{0x6b34ae, 0x6}, {{}, 0x0, {0x62bb98, 0x0}}})
        /srv/observability/build_root/go/pkg/mod/github.com/prometheus/common@v0.61.0/promslog/slog.go:79 +0x170
log/slog.(*handleState).appendAttr(0xea594c, {{0x6b34ae, 0x6}, {{}, 0x0, {0x62bb98, 0x0}}})
        /srv/observability/build_root/opt/go/src/log/slog/handler.go:475 +0x22c
log/slog.(*handleState).appendNonBuiltIns.func1({{0x6b34ae, 0x6}, {{}, 0x0, {0x62bb98, 0x0}}})
        /srv/observability/build_root/opt/go/src/log/slog/handler.go:342 +0x30
log/slog.Record.Attrs({{0xc1dac382ead53203, 0x11c55fd, 0xb3d998}, {0x6baa83, 0xf}, 0x0, 0x5ccbcd, {{{0x6b4607, 0x7}, {{...}, ...}}, ...}, ...}, ...)
        /srv/observability/build_root/opt/go/src/log/slog/record.go:84 +0x74
log/slog.(*handleState).appendNonBuiltIns(0xea594c, {{0xc1dac382ead53203, 0x11c55fd, 0xb3d998}, {0x6baa83, 0xf}, 0x0, 0x5ccbcd, {{{0x6b4607, 0x7}, ...}, ...}, ...})
        /srv/observability/build_root/opt/go/src/log/slog/handler.go:341 +0x444
log/slog.(*commonHandler).handle(0xcd2140, {{0xc1dac382ead53203, 0x11c55fd, 0xb3d998}, {0x6baa83, 0xf}, 0x0, 0x5ccbcd, {{{0x6b4607, 0x7}, ...}, ...}, ...})
        /srv/observability/build_root/opt/go/src/log/slog/handler.go:308 +0x4a4
log/slog.(*TextHandler).Handle(0xca2690, {0x78c048, 0xb49b80}, {{0xc1dac382ead53203, 0x11c55fd, 0xb3d998}, {0x6baa83, 0xf}, 0x0, 0x5ccbcd, ...})
        /srv/observability/build_root/opt/go/src/log/slog/text_handler.go:95 +0x30
log/slog.(*Logger).log(0xca2698, {0x78c048, 0xb49b80}, 0x0, {0x6baa83, 0xf}, {0xea5cc8, 0x8, 0x8})
        /srv/observability/build_root/opt/go/src/log/slog/logger.go:257 +0x15c
log/slog.(*Logger).Info(...)
        /srv/observability/build_root/opt/go/src/log/slog/logger.go:210
main.(*smokePingers).start(0xcb68d0)
        /srv/observability/build_root/smokeping_prober_src/smokeping_prober/main.go:108 +0x338
main.main()
        /srv/observability/build_root/smokeping_prober_src/smokeping_prober/main.go:263 +0x1bf8

```
