### PR TITLE
add traffic class setting/option

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"fmt"
 	"net"
+	"strconv"
 
 	probing "github.com/prometheus-community/pro-bing"
 
@@ -110,7 +110,7 @@ func (s *SmokepingCollector) updatePingers(pingers []*probing.Pinger, pingRespon
 		ipAddr := pinger.IPAddr().String()
 		host := pinger.Addr()
 		source := pinger.Source
-		tos := fmt.Sprintf("%d", pinger.TrafficClass())
+		tos := strconv.Itoa(int(pinger.TrafficClass()))
 		pingResponseDuplicates.WithLabelValues(ipAddr, host, source, tos)
 		pingResponseSeconds.WithLabelValues(ipAddr, host, source, tos)
 		pingResponseTTL.WithLabelValues(ipAddr, host, source, tos)
@@ -169,7 +169,7 @@ func (s *SmokepingCollector) Collect(ch chan<- prometheus.Metric) {
 			stats.IPAddr.String(),
 			stats.Addr,
 			pinger.Source,
-			fmt.Sprintf("%d", pinger.TrafficClass()),
+			strconv.Itoa(int(pinger.TrafficClass())),
 		)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,7 @@ type TargetGroup struct {
 	Protocol string        `yaml:"protocol,omitempty"`
 	Size     int           `yaml:"size,omitempty"`
 	Source   string        `yaml:"source,omitempty"`
+	ToS      uint8         `yaml:"tos,omitempty"`
 	// TODO: Needs work to fix MetricFamily consistency.
 	// Labels   map[string]string `yaml:"labels,omitempty"`
 }

--- a/smokeping_prober.yml
+++ b/smokeping_prober.yml
@@ -7,3 +7,4 @@ targets:
   protocol: icmp # One of icmp, udp. Default: icmp (Requires privileged operation)
   size: 56 # Packet data size in bytes. Default 56 (Range: 24 - 65535)
   source: 127.0.1.1 # Souce IP address to use. Default: None (automatic selection)
+  tos: 0x00 # Packet ToS field in decimal, hexadecimal or binary format. Default: 0 (Range: 0-255)


### PR DESCRIPTION
Generally, the ToS/Traffic class field of packets is ignored by a lot of upstream devices. However, I have some use case where having the option to control the ToS field actually delivers some useful data (the routing directs packets to different QoS and uplinks based on the DSCP/ToS field).

I'd love to see this feature get accepted upstream, however I understand that adding another label field and some additional logic for these labels will bring additional maintenance and I'd be happy to keep it in a fork.

The additional label is needed since it is now possible to have multiple target groups with the same hosts, but different ToS values. I solved this with the `tos` label. I'll be running this at home and at a production event later this month to validate the stability.