### PR TITLE
fix: disable ttl statistics to fix memory leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func (s *smokePingers) prepare(hosts *[]string, interval *time.Duration, privile
 
 		pinger.Interval = *interval
 		pinger.RecordRtts = false
+		pinger.RecordTTLs = false
 		pinger.SetPrivileged(*privileged)
 		pinger.Size = *sizeBytes
 		pinger.SetTrafficClass(*tosField)
@@ -167,6 +168,7 @@ func (s *smokePingers) prepare(hosts *[]string, interval *time.Duration, privile
 			pinger = probing.New(host)
 			pinger.Interval = targetGroup.Interval
 			pinger.RecordRtts = false
+			pinger.RecordTTLs = false
 			pinger.SetNetwork(targetGroup.Network)
 			pinger.Size = packetSize
 			pinger.SetTrafficClass(targetGroup.ToS)


### PR DESCRIPTION
With https://github.com/prometheus-community/pro-bing/pull/117 a change to the Pinger was introduced that saves all TTL values in a slice by default. This results in a memory leak because there is no cleanup mechanism for that slice. This PR disables this TTL statistic, as is already done with RTT, presumably for the same reason.