### PR TITLE
Capture pinger errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,20 @@ func (s *smokePingers) start() {
 	for _, pr := range s.started {
 		pinger := pr.pinger
 		logger.Info("Starting prober", "address", pinger.Addr(), "interval", pinger.Interval, "size_bytes", pinger.Size, "source_address", pinger.Source)
-		s.g.Go(pinger.Run)
+		s.g.Go(
+			func() error {
+				err := pinger.Run()
+				if err != nil {
+					logger.Warn("Pinger exited with error",
+						"address", pinger.Addr(),
+						"interval", pinger.Interval,
+						"size_bytes", pinger.Size,
+						"source_address", pinger.Source,
+						"err", err,
+					)
+				}
+				return err
+			})
 		time.Sleep(splay)
 	}
 	s.prepared = nil


### PR DESCRIPTION
Wrap the pinger run with an warning error so we can capture individual errors rather than waiting for the whole error group to exit.

Fixes: https://github.com/SuperQ/smokeping_prober/issues/213